### PR TITLE
bug fixed#fixed some unit test can't run.  fixed an api name upgrade from Laravel 5.3.* to Laravel 5.4.*

### DIFF
--- a/src/Frozennode/Administrator/DataTable/Columns/Relationships/HasOneOrMany.php
+++ b/src/Frozennode/Administrator/DataTable/Columns/Relationships/HasOneOrMany.php
@@ -2,6 +2,8 @@
 
 namespace Frozennode\Administrator\DataTable\Columns\Relationships;
 
+use Illuminate\Foundation\Application;
+
 class HasOneOrMany extends Relationship
 {
     /**
@@ -22,9 +24,24 @@ class HasOneOrMany extends Relationship
         //grab the existing where clauses that the user may have set on the relationship
         $relationshipWheres = $this->getRelationshipWheres($relationship, $field_table);
 
+        // bugfix upgrade Laravel 5.3.* to Laravel 5.4.*
+        // Why not use app()->version() ?
+        // Because in unit test, the Application can't init, it can easy to run the unit test.
+        if (version_compare(Application::VERSION, '5.4.0', '<')) {
+            /**
+             * @link https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L388
+             */
+            $plainForeignKey = $relationship->getPlainForeignKey();
+        } else {
+            /**
+             * @link https://github.com/laravel/framework/blob/5.4/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L401
+             */
+            $plainForeignKey = $relationship->getForeignKeyName();
+        }
+
         $where = $this->tablePrefix.$relationship->getQualifiedParentKeyName().
                 ' = '.
-                $field_table.'.'.$relationship->getPlainForeignKey()
+                $field_table.'.'.$plainForeignKey
                 .($relationshipWheres ? ' AND '.$relationshipWheres : '');
 
         $selects[] = $this->db->raw('(SELECT '.$this->getOption('select').'

--- a/tests/DataTable/Columns/Relationships/HasOneOrManyTest.php
+++ b/tests/DataTable/Columns/Relationships/HasOneOrManyTest.php
@@ -58,7 +58,7 @@ class HasOneOrManyTest extends \PHPUnit_Framework_TestCase
 
     public function testFilterQuery()
     {
-        $relationship = m::mock(array('getPlainForeignKey' => '', 'getQualifiedParentKeyName' => 'table.column', 'getRelated' => m::mock(array('getTable' => 'table'))));
+        $relationship = m::mock(array('getForeignKeyName' => '', 'getPlainForeignKey' => '', 'getQualifiedParentKeyName' => 'table.column', 'getRelated' => m::mock(array('getTable' => 'table'))));
         $model        = m::mock(array('getTable' => 'table', 'getKeyName' => '', 'method' => $relationship));
         $grammar      = m::mock('Illuminate\Database\Query\Grammars');
         $grammar->shouldReceive('wrap')->once()->andReturn('');

--- a/tests/Fields/Relationships/BelongsToManyTest.php
+++ b/tests/Fields/Relationships/BelongsToManyTest.php
@@ -84,7 +84,7 @@ class BelongsToManyTest extends \PHPUnit_Framework_TestCase
     {
         $relatedModel = m::mock(array('getKeyName' => 'id', 'getTable' => 'other_table'));
         $relationship = m::mock(array('getRelated' => $relatedModel, 'getForeignKey' => 'some_id', 'getOtherKey' => 'some_other_id',
-                                        'getTable' => 'table', ));
+                                        'getTable' => 'table', 'getQualifiedForeignPivotKeyName' => 'table.some_id', 'getQualifiedRelatedPivotKeyName' => 'table.some_other_id'));
         $model = m::mock(array('field' => $relationship, 'getTable' => 'table'));
         $this->config->shouldReceive('getDataModel')->twice()->andReturn($model);
         $this->validator->shouldReceive('arrayGet')->times(6);

--- a/tests/Fields/Relationships/HasOneOrManyTest.php
+++ b/tests/Fields/Relationships/HasOneOrManyTest.php
@@ -58,7 +58,8 @@ class HasOneOrManyTest extends \PHPUnit_Framework_TestCase
     public function testBuild()
     {
         $relatedModel = m::mock(array('getKeyName' => 'id', 'getTable' => 'other_table'));
-        $relationship = m::mock(array('getRelated' => $relatedModel, 'getForeignKey' => 'some_id', 'getPlainForeignKey' => 'some_other_id'));
+        $relationship = m::mock(array('getRelated' => $relatedModel, 'getForeignKey' => 'some_id',
+                                      'getPlainForeignKey' => 'some_other_id', 'getQualifiedForeignKeyName' => 'some_id'));
         $model        = m::mock(array('field' => $relationship, 'getTable' => 'table'));
         $this->config->shouldReceive('getDataModel')->twice()->andReturn($model);
         $this->validator->shouldReceive('arrayGet')->times(6);


### PR DESCRIPTION
1. when i clone the project and run the test, it can't pass all test, i find the unit test has some wrong and fix it.

2. `Call to undefined method Illuminate\Database\Query\Builder::getPlainForeignKey()`, i find the api name is different between [Laravel 5.3.*](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L388) and [Laravel 5.4.*](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L401)