### PR TITLE
Fix Enum.php

### DIFF
--- a/src/Frozennode/Administrator/Fields/Enum.php
+++ b/src/Frozennode/Administrator/Fields/Enum.php
@@ -30,7 +30,7 @@ class Enum extends Field
         //iterate over the options to create the options assoc array
         foreach ($dataOptions as $val => $text) {
             $options['options'][] = array(
-                'id'   => is_numeric($val) ? $text : $val,
+                'id'   => is_string($val) ? $text : $val,
                 'text' => $text,
             );
         }


### PR DESCRIPTION
修改了Enum.php中的build函数
修改
'id'   => is_numeric($val) ? $text : $val,
修改成
'id'   => is_string($val) ? $text : $val,

原来的判断写法 与文档administrator/docs/field-type-enum.md有冲突
文档中写
if the key is a string, the key will be saved to the database while the value will be presented to the user.
如果键是字符串，则键将保存到数据库中，而值将呈现给用户。

但当options为
'state'=>[
'title'=>'审核',
'type'=>'enum',
'options'=>array('1'=>'未审核','2'=>'过审核','3'=>'不过审核'),
],
这种情况时 会判断错误 所以更改为is_string()来做判断更为合理

渣渣第一次在github上给开源项目改代码  不知道改的对不对  
请summer大佬指点谢谢